### PR TITLE
Fix order transaction info with single transaction response

### DIFF
--- a/lib/HiPay/Fullservice/Gateway/Client/GatewayClient.php
+++ b/lib/HiPay/Fullservice/Gateway/Client/GatewayClient.php
@@ -239,9 +239,16 @@ class GatewayClient implements GatewayClientInterface{
         }
 
         $transactions = array();
-        foreach ($data['transaction'] as $transaction) {
-            $transactionMapper = new TransactionMapper($transaction);
+
+        // Single transaction response
+        if (!empty($data['transaction']['state'])) {
+            $transactionMapper = new TransactionMapper($data['transaction']);
             $transactions[] = $transactionMapper->getModelObjectMapped();
+        } else { // Array of transactions
+            foreach ($data['transaction'] as $transaction) {
+                $transactionMapper = new TransactionMapper($transaction);
+                $transactions[] = $transactionMapper->getModelObjectMapped();
+            }
         }
 
         return $transactions;


### PR DESCRIPTION
Hi,

I just discovered that the API can return a single transaction, and not always an array.
During all my tests with #9 I had an array, but I didn't tried with another order/transaction... :disappointed: 

Maybe the doc here https://developer.hipay.com/doc-api/enterprise/gateway/#!/transaction/getOrderTransactions needs an update to indicates than the API can return an array of transaction OR a transaction, in the same key: `transaction`

Can you test it + tag a bug release, please?