### PR TITLE
Better Exception types in SimpleHTTPClient

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
 		"email" : "support.tpp@hipay.com"
 	},
 	"require" : {
-		"php" : ">=5.6.0"
+		"php" : ">=5.6.0",
+		"ext-curl": "*"
 	},
 	"require-dev" : {
 		"phpunit/phpunit" : "6.2.*",

--- a/lib/HiPay/Fullservice/Exception/ApiErrorException.php
+++ b/lib/HiPay/Fullservice/Exception/ApiErrorException.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * HiPay Fullservice SDK PHP
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Apache 2.0 Licence
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * @copyright      Copyright (c) 2016 - HiPay
+ * @license        http://www.apache.org/licenses/LICENSE-2.0 Apache 2.0 Licence
+ *
+ */
+namespace HiPay\Fullservice\Exception;
+
+/**
+ * Exception thrown if the Hipay API returns a specific error.
+ *
+ * @category    HiPay
+ * @package     HiPay\Fullservice
+ * @author 		Kassim Belghait <kassim@sirateck.com>
+ * @copyright   Copyright (c) 2016 - HiPay
+ * @license     http://www.apache.org/licenses/LICENSE-2.0 Apache 2.0 License
+ * @link 		https://github.com/hipay/hipay-fullservice-sdk-php
+ */
+class ApiErrorException extends \RuntimeException {
+}

--- a/lib/HiPay/Fullservice/Exception/CurlException.php
+++ b/lib/HiPay/Fullservice/Exception/CurlException.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * HiPay Fullservice SDK PHP
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Apache 2.0 Licence
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * @copyright      Copyright (c) 2016 - HiPay
+ * @license        http://www.apache.org/licenses/LICENSE-2.0 Apache 2.0 Licence
+ *
+ */
+namespace HiPay\Fullservice\Exception;
+
+/**
+ * Exception thrown if a cUrl error occurs.
+ *
+ * @category    HiPay
+ * @package     HiPay\Fullservice
+ * @author 		Kassim Belghait <kassim@sirateck.com>
+ * @copyright   Copyright (c) 2016 - HiPay
+ * @license     http://www.apache.org/licenses/LICENSE-2.0 Apache 2.0 License
+ * @link 		https://github.com/hipay/hipay-fullservice-sdk-php
+ */
+class CurlException extends \RuntimeException {
+}

--- a/lib/HiPay/Fullservice/Exception/HttpErrorException.php
+++ b/lib/HiPay/Fullservice/Exception/HttpErrorException.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * HiPay Fullservice SDK PHP
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Apache 2.0 Licence
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * @copyright      Copyright (c) 2016 - HiPay
+ * @license        http://www.apache.org/licenses/LICENSE-2.0 Apache 2.0 Licence
+ *
+ */
+namespace HiPay\Fullservice\Exception;
+
+/**
+ * Exception thrown if the Hipay API returns a HTTP error.
+ *
+ * @category    HiPay
+ * @package     HiPay\Fullservice
+ * @author 		Kassim Belghait <kassim@sirateck.com>
+ * @copyright   Copyright (c) 2016 - HiPay
+ * @license     http://www.apache.org/licenses/LICENSE-2.0 Apache 2.0 License
+ * @link 		https://github.com/hipay/hipay-fullservice-sdk-php
+ */
+class HttpErrorException extends \RuntimeException {
+}

--- a/lib/HiPay/Fullservice/HTTP/SimpleHTTPClient.php
+++ b/lib/HiPay/Fullservice/HTTP/SimpleHTTPClient.php
@@ -16,6 +16,9 @@
 
 namespace HiPay\Fullservice\HTTP;
 
+use HiPay\Fullservice\Exception\ApiErrorException;
+use HiPay\Fullservice\Exception\CurlException;
+use HiPay\Fullservice\Exception\HttpErrorException;
 use HiPay\Fullservice\HTTP\ClientProvider;
 use HiPay\Fullservice\Exception\InvalidArgumentException;
 use HiPay\Fullservice\Exception\RuntimeException;
@@ -87,42 +90,34 @@ class SimpleHTTPClient extends ClientProvider
             $options[CURLOPT_PROXYUSERPWD] = $proxyConfiguration["user"] . ":" . $proxyConfiguration["password"];
         }
 
-        try {
+        /**
+         * Send a new request
+         * $method can be any valid HTTP METHOD (GET, POST etc ...)
+         * $uri The url/endpoint to request
+         * $options Needed configuration
+         */
+        foreach ($options as $option => $value) {
+            curl_setopt($this->_httpClient, $option, $value);
+        }
 
-            /**
-             * Send a new request
-             * $method can be any valid HTTP METHOD (GET, POST etc ...)
-             * $uri The url/endpoint to request
-             * $options Needed configuration
-             */
-            foreach ($options as $option => $value) {
-                curl_setopt($this->_httpClient, $option, $value);
+        // execute the given cURL session
+        if (false === ($result = curl_exec($this->_httpClient))) {
+            throw new CurlException(curl_error($this->_httpClient), curl_errno($this->_httpClient));
+        }
+
+        //$header_size = curl_getinfo($this->_httpClient, CURLINFO_HEADER_SIZE);
+        //$header = substr($result, 0, $header_size); @TODO transform headers to array
+        $body = $result; //substr($result, $header_size);
+
+        $status = (int)curl_getinfo($this->_httpClient, CURLINFO_HTTP_CODE);
+        $httpResponse = json_decode($body);
+
+        if (floor($status / 100) != 2) {
+            if (is_object($httpResponse) && isset($httpResponse->message, $httpResponse->code)) {
+                throw new ApiErrorException($httpResponse->message, $httpResponse->code);
+            } else {
+                throw new HttpErrorException($body, $status);
             }
-
-            // execute the given cURL session
-            if (false === ($result = curl_exec($this->_httpClient))) {
-                throw new RuntimeException(curl_error($this->_httpClient), curl_errno($this->_httpClient));
-            }
-
-            //$header_size = curl_getinfo($this->_httpClient, CURLINFO_HEADER_SIZE);
-            //$header = substr($result, 0, $header_size); @TODO transform headers to array
-            $body = $result; //substr($result, $header_size);
-
-            $status = (int)curl_getinfo($this->_httpClient, CURLINFO_HTTP_CODE);
-            $httpResponse = json_decode($body);
-
-            if (floor($status / 100) != 2) {
-                $message = $body;
-                $code = $status;
-                if (is_object($httpResponse)) {
-                    $message = $httpResponse->message;
-                    $code = $httpResponse->code;
-                }
-                throw new RuntimeException($message, $code);
-            }
-
-        } catch (\Exception $e) {
-            throw new RuntimeException($e->getMessage(), $e->getCode(), $e);
         }
 
         //Return a simple response object

--- a/tests/unit/HiPay/Tests/Fullservice/HTTP/SimpleHTTPClientTest.php
+++ b/tests/unit/HiPay/Tests/Fullservice/HTTP/SimpleHTTPClientTest.php
@@ -120,17 +120,47 @@ class SimpleHTTPClientTest extends TestCase {
 		$client->request('GETTED', "1234");
 	
 	}
-	
-	/**
-	 * @cover HiPay\Fullservice\HTTP\SimpleHTTPClient::request
-	 * @depends testCanBeConstructUsingConfiguration
-	 * @expectedException HiPay\Fullservice\Exception\RuntimeException
-	 */
-	public function testRuntimeExecptionIsRaisedForNetworkFailure(ClientProvider $client){
-	
-		$client->request('GETTED', "1234");
-	
-	}
-	
 
+    /**
+     * @cover HiPay\Fullservice\HTTP\SimpleHTTPClient::request
+     * @expectedException HiPay\Fullservice\Exception\CurlException
+     * @expectedExceptionMessage Could not resolve host
+     */
+    public function testCurlExceptionIsRaisedForNetworkFailure()
+    {
+        $mock = $this->createMock(Configuration::class);
+        $mock->method('getApiEndpoint')->willReturn('http://domain.invalid');
+        $client = new SimpleHTTPClient($mock);
+        $client->request('GET', "/");
+    }
+
+    /**
+     * http://www.mocky.io/v2/5b80129d3400005400dc0727 mocks an API error json response
+     *
+     * @cover HiPay\Fullservice\HTTP\SimpleHTTPClient::request
+     * @expectedException HiPay\Fullservice\Exception\ApiErrorException
+     * @expectedExceptionCode 123123123
+     */
+    public function testApiErrorExceptionIsRaisedForParsableHttpResponse()
+    {
+        $mock = $this->createMock(Configuration::class);
+        $mock->method('getApiEndpoint')->willReturn('http://www.mocky.io');
+        $client = new SimpleHTTPClient($mock);
+        $client->request('GET', "/v2/5b80129d3400005400dc0727");
+    }
+
+    /**
+     * http://www.mocky.io/v2/5b8013903400007700dc072b mocks a not parsable HTTP 500 error
+     *
+     * @cover HiPay\Fullservice\HTTP\SimpleHTTPClient::request
+     * @expectedException HiPay\Fullservice\Exception\HttpErrorException
+     * @expectedExceptionCode 500
+     */
+    public function testHttpErrorExceptionIsRaisedForNotParsableHttpResponse()
+    {
+        $mock = $this->createMock(Configuration::class);
+        $mock->method('getApiEndpoint')->willReturn('http://www.mocky.io');
+        $client = new SimpleHTTPClient($mock);
+        $client->request('GET', "/v2/5b8013903400007700dc072b");
+    }
 }


### PR DESCRIPTION
Hello,

Here a Pull Request to throw more specific Exceptions in  `SimpleHTTPClient` :

* `CurlException` on a curl error
* `HttpErrorException` on a not parsable HTTP Exception
* `ApiErrorException` on a "normal" error returned by the API
 
All these 3 Exceptions extends `RuntimeException` and are instanciated with the same code/message, so it should be backward compatible.
