### PR TITLE
Swap $operation and $basket in the Transaction constructor parameters

### DIFF
--- a/lib/HiPay/Fullservice/Gateway/Mapper/TransactionMapper.php
+++ b/lib/HiPay/Fullservice/Gateway/Mapper/TransactionMapper.php
@@ -141,8 +141,8 @@ class TransactionMapper extends AbstractMapper
             $fraudScreening,
             $order,
             $debitAgreement,
-            $basket,
             $operation,
+            $basket,
             $customData
         );
     }

--- a/lib/HiPay/Fullservice/Gateway/Model/Transaction.php
+++ b/lib/HiPay/Fullservice/Gateway/Model/Transaction.php
@@ -60,8 +60,8 @@ class Transaction extends AbstractTransaction
         $fraudScreening,
         $order,
         $debitAgreement,
-        $basket = null,
         $operation,
+        $basket = null,
         $customData = null
     ) {
         parent::__construct(


### PR DESCRIPTION
In PHP 8.0, adding required parameters after optional parameters was deprecated.
 
`Required parameter $operation follows optional parameter $basket at /hipay-fullservice-sdk-php/lib/HiPay/Fullservice/Gateway/Model/Transaction.php:32`

This is fixed by swapping the $operation and $basket parameters.
